### PR TITLE
Added download_tour_gpx_string function

### DIFF
--- a/example.py
+++ b/example.py
@@ -30,7 +30,7 @@ def main():
     tour_id = tours[0]["id"]
 
     # Download the tour to the specified directory
-    file_name = a.download_tour_gpx(tour_id, _DOWNLOAD_DIR)
+    file_name = a.download_tour_gpx_file(tour_id, _DOWNLOAD_DIR)
 
     # Upload the downloaded tour as an recorded activity
     a.upload_tour_gpx(Sport.BIKE_TOURING, _DOWNLOAD_DIR + "/" + file_name,

--- a/komPYoot/api.py
+++ b/komPYoot/api.py
@@ -350,6 +350,33 @@ class API():
             file_name if download is successful, None otherwise.
 
         """
+        gpx_txt = self.download_tour_gpx_string(tour_id)
+        gpx_tree = ET.fromstring(gpx_txt)
+        file_name = gpx_tree[0][0].text + ".gpx"
+        with open(download_dir + "/" + file_name, "w") as f:
+            f.write(gpx_txt)
+        return file_name
+
+    def download_tour_gpx_string(self, tour_id):
+        """
+        Download GPX string of tour.
+
+        Parameters
+        ----------
+        tour_id : str
+            Tour ID.
+
+        Raises
+        ------
+        RuntimeError
+            If no user is logged-in.
+
+        Returns
+        -------
+        str or None
+            gpx_string if download is successful, None otherwise.
+
+        """
         if (self.user_details == {}):
             raise RuntimeError("User Details Not Available. Please Sign In.")
         resp = requests.get(_TOUR_DL_GPX_URL % tour_id,
@@ -360,11 +387,7 @@ class API():
                           resp.status_code)
             return None
         gpx_txt = resp.text
-        gpx_tree = ET.fromstring(gpx_txt)
-        file_name = gpx_tree[0][0].text + ".gpx"
-        with open(download_dir + "/" + file_name, "w") as f:
-            f.write(resp.text)
-        return file_name
+        return gpx_txt
 
     def upload_tour_gpx(self, sport, file_path, duration=None):
         """

--- a/komPYoot/api.py
+++ b/komPYoot/api.py
@@ -328,7 +328,7 @@ class API():
 
         return tours
 
-    def download_tour_gpx(self, tour_id, download_dir):
+    def download_tour_gpx_file(self, tour_id, download_dir):
         """
         Download tour in the GPX format.
 


### PR DESCRIPTION
Hi,
first of all, your project is very awesome and saved me a ton of time on my komoot Heatmap project, Thank you!

I added the `API.download_tour_gpx_string(self, tour_id)`  function which allows the user
to download the tour and returns the GPX string instead of saving it as a file.
Of course, I also left the `API.download_tour_gpx(self, tour_id, download_dir)` there.

Thanks again and have a nice day 😊